### PR TITLE
feat(register): add RegisterActivity with UI and basic navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
         </activity>
 
         <activity
+            android:name=".ui.register.RegisterActivity"
+            android:exported="true" />
+
+        <activity
             android:name=".ui.menu.MenuActivity"
             android:exported="true" />
 

--- a/app/src/main/java/pe/drcausa/android_mvvm_template/ui/register/RegisterActivity.java
+++ b/app/src/main/java/pe/drcausa/android_mvvm_template/ui/register/RegisterActivity.java
@@ -1,0 +1,47 @@
+package pe.drcausa.android_mvvm_template.ui.register;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textview.MaterialTextView;
+
+import pe.drcausa.android_mvvm_template.R;
+
+public class RegisterActivity extends AppCompatActivity {
+    private TextInputEditText edtUsername, edtEmail, edtPassword, edtConfirmPassword;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_register);
+
+        edtUsername = findViewById(R.id.edtUsername);
+        edtEmail = findViewById(R.id.edtEmail);
+        edtPassword = findViewById(R.id.edtPassword);
+        edtConfirmPassword = findViewById(R.id.edtConfirmPassword);
+        MaterialButton btnRegister = findViewById(R.id.btnRegister);
+        MaterialTextView txtLogin = findViewById(R.id.txtLogin);
+
+        btnRegister.setOnClickListener(v -> handleRegister());
+        txtLogin.setOnClickListener(v -> handleLogin());
+    }
+
+    private void handleRegister() {
+    }
+
+    private void handleLogin() {
+        finish();
+    }
+
+    private void clearFields() {
+        edtUsername.setText("");
+        edtEmail.setText("");
+        edtPassword.setText("");
+        edtConfirmPassword.setText("");
+    }
+}

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.register.RegisterActivity">
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:background="@color/white"
+        app:layout_constraintTop_toTopOf="@+id/main"
+        app:layout_constraintBottom_toBottomOf="@+id/main">
+        <LinearLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="32dp">
+
+            <ImageView
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_gravity="center"
+                android:src="@drawable/ic_launcher_foreground" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/app_name"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                app:textAllCaps="true"
+                android:textColor="@color/black"
+                android:gravity="center" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:hint="Username">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edtUsername"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:hint="Email">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edtEmail"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:hint="Password"
+                app:endIconMode="password_toggle">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edtPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:hint="Confirm password"
+                app:endIconMode="password_toggle">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edtConfirmPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPassword" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnRegister"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:insetLeft="0dp"
+                android:insetRight="0dp"
+                android:text="Register"
+                android:textSize="18sp"
+                android:textAllCaps="true"
+                android:backgroundTint="@color/black" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/txtLogin"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:text="Already have an account? Sign in here"
+                android:textSize="18sp"
+                android:textColor="@color/black"
+                android:gravity="center" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Implemented RegisterActivity and corresponding layout activity_register.xml for user registration.
- Added UI elements: username, email, password, confirm password, register button, and login text view.
- Initialized UI elements and set click listeners for register button and login text view.
- Added placeholder methods:
    - handleRegister() for future registration logic.
    - handleLogin() to navigate back or finish the activity.
- Added clearFields() method to reset input fields.
- Declared RegisterActivity in AndroidManifest.xml.
